### PR TITLE
Fix powerup usable when depleted

### DIFF
--- a/Managers/powerup_manager.gd
+++ b/Managers/powerup_manager.gd
@@ -50,8 +50,9 @@ func _on_use_powerup(_type: int):
     current_powerup_stage = POWERUP_STAGES.IN_USE
 
 func _on_stop_powerup():
-    current_powerup_stage = POWERUP_STAGES.UNUSED
+    if current_powerup_stage != POWERUP_STAGES.INACTIVE:
+        current_powerup_stage = POWERUP_STAGES.UNUSED
 
 func _on_powerup_depleted() -> void:
-    current_powerup_stage = POWERUP_STAGES.INACTIVE
     self.emit_signal("stop_powerup")
+    current_powerup_stage = POWERUP_STAGES.INACTIVE


### PR DESCRIPTION
The bug is caused by calling `self.emit_signal("stop_powerup")` after setting the `current_powerup_usage` to `INACTIVE`. The reason being that the `_on_stop_powerup()` handler will then set the power usage to `UNUSED`, and the game will never see it become `INACTIVE`.

I have done 2 things, each would fix the issue on its own, but by having both I am ensuring that the bug will not regress again with future changes:
- `_on_powerup_depleted()` now sets the `current_powerup_usage` to `INACTIVE` only after having emitted the `"stop_powerup"` signal.
- `_on_stop_powerup()` will no longer set the powerup state to `UNUSED` if it is already `INACTIVE`

Fixes #6 